### PR TITLE
Fix Bug:For an x13 multi-document refresh Current adjustment (partial…

### DIFF
--- a/jtss/src/main/java/ec/tss/sa/processors/X13Processor.java
+++ b/jtss/src/main/java/ec/tss/sa/processors/X13Processor.java
@@ -134,7 +134,7 @@ public class X13Processor implements ISaProcessingFactory<X13Specification> {
             ntspec.getArima().clearParameters();
         }
 
-        if (policy == EstimationPolicyType.Fixed) {
+        if (policy == EstimationPolicyType.FixedParameters) {
             ntspec.getArima().setParameterType(ParameterType.Fixed);
         }
 


### PR DESCRIPTION
…) is chosen, the coefficients of the ARIMA-Modell are not estimated. Policytype is corrected.