### PR TITLE
Bugfix: HendersonFilter wasn't saved

### DIFF
--- a/jtstoolkit/src/main/java/ec/satoolkit/x11/X11Specification.java
+++ b/jtstoolkit/src/main/java/ec/satoolkit/x11/X11Specification.java
@@ -163,7 +163,7 @@ public class X11Specification implements IProcSpecification, Cloneable {
         if (usigma_ != DEF_USIGMA) {
             return false;
         }
-        return true;
+        return isAutoHenderson();
     }
 
     public boolean isAutoHenderson() {
@@ -327,7 +327,7 @@ public class X11Specification implements IProcSpecification, Cloneable {
         if (verbose || usigma_ != DEF_USIGMA) {
             info.add(USIGMA, usigma_);
         }
-        if (verbose || henderson_ != 0) {
+        if (verbose || !isAutoHenderson()) {
             info.add(TRENDMA, henderson_);
         }
         if (filters_ != null) {


### PR DESCRIPTION
HendersonFilter wasn't saved if it was the only deviation from the
default X11Specification