### PR TITLE
Fixed Error in TradingDaysSpec

### DIFF
--- a/jtstoolkit/src/main/java/ec/tstoolkit/modelling/arima/tramo/TradingDaysSpec.java
+++ b/jtstoolkit/src/main/java/ec/tstoolkit/modelling/arima/tramo/TradingDaysSpec.java
@@ -198,6 +198,7 @@ public class TradingDaysSpec implements Cloneable, InformationSetSerializable {
             lp_ = false;
             auto_ = AutoMethod.Unused;
             pftd_ = DEF_PFTD;
+            w_ = 0;
         }
     }
 

--- a/jtstoolkit/src/main/java/ec/tstoolkit/modelling/arima/x13/TradingDaysSpec.java
+++ b/jtstoolkit/src/main/java/ec/tstoolkit/modelling/arima/x13/TradingDaysSpec.java
@@ -154,6 +154,7 @@ public class TradingDaysSpec implements Cloneable, InformationSetSerializable {
             type_ = TradingDaysType.None;
             lp_ = LengthOfPeriodType.None;
             autoAdjust_ = false;
+            w_ = 0;
         }
     }
 


### PR DESCRIPTION
Changing from StockTradingDays to UserTradingDays kept the StockTradingDays active, so JD+ would find the regressors for both.